### PR TITLE
Move region selection to defaults

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,0 +1,1 @@
+aws_region: eu-central-1

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,20 +9,9 @@
   with_items:
     - ruby
 
-- name: Get Instance Metadata
-  action: ec2_facts
-  register: ec2_facts
-
-## Default region to use for download when running locally or non ec2 instance
-- set_fact: region=eu-central-1
-  when: ec2_facts.ansible_ec2_placement_region is undefined
-
-- set_fact: region={{ ec2_facts.ansible_ec2_placement_region }}
-  when: ec2_facts.ansible_ec2_placement_region is defined
-
 - name: Download CodeDeploy Agent
   get_url:
-    url: "https://aws-codedeploy-{{ region }}.s3.amazonaws.com/latest/install"
+    url: "https://aws-codedeploy-{{ aws_region }}.s3.amazonaws.com/latest/install"
     dest: /tmp/codedeploy-install
     mode: 0755
 


### PR DESCRIPTION
The `ec2_facts` checker is causing havoc when we're testing it locally using Ansible 2.4. Move it to a parameter instead. The download location doesn't really matter, as you get the same package regardless.